### PR TITLE
Max/sql file

### DIFF
--- a/doltcli/dolt.py
+++ b/doltcli/dolt.py
@@ -581,7 +581,7 @@ class Dolt(DoltT):
             with tempfile.NamedTemporaryFile() as f:
                 args.extend(["--result-format", "csv"])
                 output_file = self.execute(args, stdout_to_file=f.name, **kwargs)
-                if result_parser is None:
+                if not hasattr(result_parser, "__call__"):
                     raise ValueError(
                         f"Invalid argument: `result_parser` should be Callable; found {type(result_parser)}"
                     )

--- a/doltcli/types.py
+++ b/doltcli/types.py
@@ -137,6 +137,7 @@ class DoltT:
         list_saved: bool = False,
         batch: bool = False,
         multi_db_dir: Optional[str] = None,
+        result_file: Optional[str] = None,
         result_parser: Optional[Callable[[str], Any]] = None,
     ) -> List:
         ...

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,20 @@
+import csv
 from typing import List
+
+
+def write_dict_to_csv(data, file):
+    csv_columns = list(data[0].keys())
+    with open(file, "w") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
+        writer.writeheader()
+        for row in data:
+            writer.writerow(row)
+
+
+def read_csv_to_dict(file):
+    with open(file, "r") as csvfile:
+        reader = csv.DictReader(csvfile)
+        return list(reader)
 
 
 def compare_rows_helper(expected: List[dict], actual: List[dict]):

--- a/tests/test_dolt.py
+++ b/tests/test_dolt.py
@@ -543,7 +543,7 @@ def test_dolt_sql_errors(doltdb):
     with pytest.raises(ValueError):
         db.sql(result_parser=lambda x: x, query=None)
     with pytest.raises(ValueError):
-        db.sql(result_parser=2, query=None)
+        db.sql(result_parser=2, query="select active_branch()")
     with pytest.raises(ValueError):
         db.sql(result_file="file.csv", query=None)
     with pytest.raises(ValueError):

--- a/tests/test_dolt.py
+++ b/tests/test_dolt.py
@@ -535,8 +535,6 @@ def test_dolt_sql_file(init_empty_test_repo):
         write_rows(dolt, 'test_table', BASE_TEST_ROWS, commit=True)
         result = dolt.sql("SELECT `name` as name, `id` as id FROM test_table ", result_file=f.name)
         res = read_csv_to_dict(f.name)
-        print(result)
-        print(res)
         compare_rows_helper(BASE_TEST_ROWS, res)
 
 def test_no_init_error(init_empty_test_repo):

--- a/tests/test_dolt.py
+++ b/tests/test_dolt.py
@@ -537,6 +537,18 @@ def test_dolt_sql_file(init_empty_test_repo):
         res = read_csv_to_dict(f.name)
         compare_rows_helper(BASE_TEST_ROWS, res)
 
+def test_dolt_sql_errors(doltdb):
+    db = Dolt(doltdb)
+
+    with pytest.raises(ValueError):
+        db.sql(result_parser=lambda x: x, query=None)
+    with pytest.raises(ValueError):
+        db.sql(result_parser=2, query=None)
+    with pytest.raises(ValueError):
+        db.sql(result_file="file.csv", query=None)
+    with pytest.raises(ValueError):
+        db.sql(result_format="csv", query=None)
+
 def test_no_init_error(init_empty_test_repo):
     dolt = init_empty_test_repo
 


### PR DESCRIPTION
Retrieving an SQL query results in a file currently requires two writes -- this PR adds a way to specify the target file to reduce this to one write for certain use-cases.