### PR TITLE
--no-gc option

### DIFF
--- a/doltcli/utils.py
+++ b/doltcli/utils.py
@@ -72,6 +72,7 @@ def write_file(
     commit_message: Optional[str] = None,
     commit_date: Optional[datetime.datetime] = None,
     do_continue: Optional[bool] = False,
+    do_gc: Optional[bool] = True,
 ):
     if file_handle is not None and file is not None:
         raise ValueError("Specify one of: file, file_handle")
@@ -103,6 +104,7 @@ def write_file(
         commit_message=commit_message,
         commit_date=commit_date,
         do_continue=do_continue,
+        do_gc=do_gc,
     )
 
 
@@ -116,6 +118,7 @@ def write_columns(
     commit_message: Optional[str] = None,
     commit_date: Optional[datetime.datetime] = None,
     do_continue: Optional[bool] = False,
+    do_gc: Optional[bool] = True,
 ):
     """
 
@@ -151,6 +154,7 @@ def write_columns(
         commit_message=commit_message,
         commit_date=commit_date,
         do_continue=do_continue,
+        do_gc=do_gc,
     )
 
 
@@ -164,6 +168,7 @@ def write_rows(
     commit_message: Optional[str] = None,
     commit_date: Optional[datetime.datetime] = None,
     do_continue: Optional[bool] = False,
+    do_gc: Optional[bool] = True,
 ):
     """
 
@@ -199,6 +204,7 @@ def write_rows(
         commit_message=commit_message,
         commit_date=commit_date,
         do_continue=do_continue,
+        do_gc=do_gc,
     )
 
 
@@ -209,6 +215,7 @@ def _import_helper(
     import_mode: Optional[str] = None,
     primary_key: Optional[List[str]] = None,
     do_continue: Optional[bool] = False,
+    do_gc: Optional[bool] = True,
     commit: Optional[bool] = False,
     commit_message: Optional[str] = None,
     commit_date: Optional[datetime.datetime] = None,
@@ -227,6 +234,8 @@ def _import_helper(
             args += ["--pk={}".format(",".join(primary_key))]
         if do_continue is True:
             args += ["--continue"]
+        if do_gc is False:
+            args += ["--no-gc"]
 
         dolt.execute(args + [import_file])
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -72,6 +72,7 @@ def test_write_file_handle(init_empty_test_repo, tmp_path):
             file_handle=open(tempfile),
             import_mode=CREATE,
             primary_key=["id"],
+            do_gc=False,
         )
     write_file(
         dolt=dolt,


### PR DESCRIPTION
write options have a `do_gc` option, which can be set `False` to add `--no-gc` to a dolt import