### PR TITLE
Decode error message so that it is printed correctly

### DIFF
--- a/doltcli/dolt.py
+++ b/doltcli/dolt.py
@@ -77,7 +77,7 @@ def _execute(args: List[str], cwd: Optional[str] = None, outfile: Optional[str] 
             proc = Popen(args=_args, cwd=cwd, stdout=f, stderr=PIPE)
     else:
         proc = Popen(args=_args, cwd=cwd, stdout=PIPE, stderr=PIPE)
-    out, err = (val.decode('utf8') for val in proc.communicate())
+    out, err = (val.decode("utf8") if val else "" for val in proc.communicate())
     exitcode = proc.returncode
 
     if exitcode != 0:

--- a/doltcli/dolt.py
+++ b/doltcli/dolt.py
@@ -77,7 +77,7 @@ def _execute(args: List[str], cwd: Optional[str] = None, outfile: Optional[str] 
             proc = Popen(args=_args, cwd=cwd, stdout=f, stderr=PIPE)
     else:
         proc = Popen(args=_args, cwd=cwd, stdout=PIPE, stderr=PIPE)
-    out, err = proc.communicate()
+    out, err = (val.decode('utf8') for val in proc.communicate())
     exitcode = proc.returncode
 
     if exitcode != 0:
@@ -87,7 +87,7 @@ def _execute(args: List[str], cwd: Optional[str] = None, outfile: Optional[str] 
     if outfile:
         return outfile
     else:
-        return out.decode("utf-8")
+        return out
 
 
 class Status(StatusT):


### PR DESCRIPTION
Before:
```python
b'\n\nA bad row was encountered while moving data.\nBad Row: \n"03AGDBQ24TPRIFU0LRPRHLHU8KBOK5SQSMCT8BMVFJNANULFUG4RDHNZPOV4PJNMN0DOD1PM2V5AQQTFP1HZXZG5J5BJTP7BN0A8WLBZYMBJIRU7BWTYCNXTCQUD1UYWITEJIZR5EWWP1NM4OR40P6FTQL4NHKIA870UAFXSPRF0AIK_45YNRU98ZQOZQNJFKNF89FW9" is not valid for "street_physical"\nThese can be ignored using the \'--continue\'\n'
```

After:
```python
A bad row was encountered while moving data.
Bad Row: 
"03AGDBQ24TPRIFU0LRPRHLHU8KBOK5SQSMCT8BMVFJNANULFUG4RDHNZPOV4PJNMN0DOD1PM2V5AQQTFP1HZXZG5J5BJTP7BN0A8WLBZYMBJIRU7BWTYCNXTCQUD1UYWITEJIZR5EWWP1NM4OR40P6FTQL4NHKIA870UAFXSPRF0AIK_45YNRU98ZQOZQNJFKNF89FW9" is not valid for "street_physical" (schema "VarString(utf8mb4_0900_ai_ci, 180, SQL: VarChar)")
These can be ignored using the '--continue'
```