### PR TITLE
Update utils.py - replace/force-create import_mode were not being handled

### DIFF
--- a/doltcli/utils.py
+++ b/doltcli/utils.py
@@ -254,6 +254,8 @@ def _get_import_mode_and_flags(
     import_modes = IMPORT_MODES_TO_FLAGS.keys()
     if import_mode and import_mode not in import_modes:
         raise ValueError(f"update_mode must be one of: {import_modes}")
+    elif import_mode:
+        return import_mode
     else:
         if table in [table.name for table in dolt.ls()]:
             logger.info(f'No import mode specified, table exists, using "{UPDATE}"')


### PR DESCRIPTION
code snippet to reproduce:
doltcli
`write_rows(write_rows(dolt, "characters", TEST_ROWS, REPLACE, ["id"])`

or via doltpy:
`write_pandas(dolt, table_name, df, import_mode='replace')`

both call `_import_helper` which refers to 

https://github.com/dolthub/doltcli/blob/a807c93d01d2f76beb0260a76a8bd58a40b1c7ad/doltcli/utils.py#L251-L265

the checks force it to return only `create/update` mode depending on existence of table, `replace/force-create` modes are ignored