### PR TITLE
Allow ~ and fix for schema_export

### DIFF
--- a/doltcli/dolt.py
+++ b/doltcli/dolt.py
@@ -267,6 +267,8 @@ class Dolt(DoltT):
     """
 
     def __init__(self, repo_dir: str, print_output: Optional[bool] = None):
+        # allow ~ to be used in paths
+        repo_dir = os.path.expanduser(repo_dir)
         self.repo_dir = repo_dir
         self._print_output = print_output or False
 

--- a/doltcli/dolt.py
+++ b/doltcli/dolt.py
@@ -1368,7 +1368,7 @@ class Dolt(DoltT):
         args = ["schema", "export", table]
 
         if filename:
-            args.extend(["--filename", filename])
+            args.extend([filename])
             _execute(args, self.repo_dir)
             return True
         else:

--- a/tests/test_dolt.py
+++ b/tests/test_dolt.py
@@ -111,6 +111,16 @@ def test_init(tmp_path):
     Dolt.init(repo_path)
     assert os.path.exists(repo_data_dir)
     shutil.rmtree(repo_data_dir)
+    
+def test_home_path():
+    path = "~/.dolt_test"
+    os.mkdir(path)
+
+    repo_path, repo_data_dir = get_repo_path_tmp_path("path")
+    assert not os.path.exists(repo_data_dir)
+    Dolt.init(repo_path)
+    assert os.path.exists(repo_data_dir)
+    shutil.rmtree(repo_data_dir)
 
 
 def test_bad_repo_path(tmp_path):


### PR DESCRIPTION
- Allows ~ in the path when creating a new Dolt object
- Fixes a schema_export, the cli seems to have removed the need to for --filename flag